### PR TITLE
Add planned state for projects in manual planning mode

### DIFF
--- a/lib/git-routines/plugins/pivotal.rb
+++ b/lib/git-routines/plugins/pivotal.rb
@@ -55,7 +55,7 @@ def stories
 end
 
 def filter
-  "current_state:unscheduled,unstarted,rejected mywork:#{@user_initials}"
+  "current_state:unscheduled,unstarted,rejected,planned mywork:#{@user_initials}"
 end
 
 def select_story


### PR DESCRIPTION
In some projects we use the "manual mode" for better overriding the sometimes very limited automatic mode of Pivotal. In this case the Tracker API does not list any stories because it needs the state "planned" as a filter.
